### PR TITLE
Add IPA tooltip feature using Epitran

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ source venv/bin/activate
 pip install -r requirements.txt
 ```
 
+This project uses [Epitran](https://github.com/dmort27/epitran) to display IPA
+pronunciations. On Debian/Ubuntu you also need the `flite` and `flite1-dev`
+packages so the `t2p` executable is available:
+
+```bash
+sudo apt-get install flite flite1-dev
+```
+
 
 The backend uses the [faster-whisper](https://github.com/guillaumekln/faster-whisper)
 `base.en` model locally. If you place your `OPENAI_API_KEY` in a `.env` file in

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ flask>=3.0
 faster-whisper>=0.10
 python-dotenv>=1.0
 openai>=1.3
+epitran>=1.2
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -50,6 +50,28 @@
     margin-bottom:1.75rem;
   }
 
+  .word {
+    position:relative;
+    cursor:help;
+  }
+  .word::after {
+    content:attr(data-ipa);
+    position:absolute;
+    left:50%;
+    bottom:120%;
+    transform:translateX(-50%);
+    background:#333;
+    color:#fff;
+    padding:2px 6px;
+    border-radius:4px;
+    font-size:.8rem;
+    white-space:nowrap;
+    opacity:0;
+    pointer-events:none;
+    transition:opacity .15s;
+  }
+  .word:hover::after { opacity:1; }
+
   #loader {
     display:none;
     margin:0 auto 1.5rem;
@@ -142,7 +164,7 @@ async function pickSentence() {
       .map(t => {
         if (/\b[\w']+\b/.test(t)) {
           const tip = ipa[idx++] || "";
-          return `<span title="${tip}">${t}</span>`;
+          return `<span class="word" data-ipa="${tip}">${t}</span>`;
         }
         return t;
       })

--- a/templates/index.html
+++ b/templates/index.html
@@ -134,7 +134,20 @@ async function pickSentence() {
     clearTimeout(show);
     loader.style.display = "none";
     currentSentence = data.sentence;
-    document.getElementById("sentence-box").textContent = currentSentence;
+    const tokens = data.words;
+    const ipa = data.ipa;
+    const parts = currentSentence.split(/(\b[\w']+\b)/g);
+    let idx = 0;
+    const html = parts
+      .map(t => {
+        if (/\b[\w']+\b/.test(t)) {
+          const tip = ipa[idx++] || "";
+          return `<span title="${tip}">${t}</span>`;
+        }
+        return t;
+      })
+      .join("");
+    document.getElementById("sentence-box").innerHTML = html;
     document.getElementById("transcript").textContent = "";
     document.getElementById("comparison").innerHTML = "";
   } catch (err) {


### PR DESCRIPTION
## Summary
- use epitran via FliteT2P to generate phonetic transcriptions
- expose IPA for each word from `/random-sentence`
- render generated sentence with tooltips showing IPA when hovering
- document dependency on epitran

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68570fb601308326a5bbaadcf4d0b5aa