### PR TITLE
Add per-word playback on click

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -179,7 +179,20 @@ async function pickSentence() {
   }
 }
 
-document.addEventListener("DOMContentLoaded", pickSentence);
+function speakWord(word) {
+  const utterance = new SpeechSynthesisUtterance(word);
+  utterance.lang = 'en-US';
+  window.speechSynthesis.speak(utterance);
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  pickSentence();
+  document.getElementById("sentence-box").addEventListener("click", e => {
+    if (e.target.classList.contains("word")) {
+      speakWord(e.target.textContent);
+    }
+  });
+});
 
 const CONF_THRESHOLD = 0.6;
 function tokenize(t){


### PR DESCRIPTION
## Summary
- add a `speakWord` helper that uses SpeechSynthesis
- pronounce any word in the practice sentence when clicked

## Testing
- `python -m py_compile app.py`
- `black -l 88 app.py`

------
https://chatgpt.com/codex/tasks/task_e_68571c56e40c832682086cc5b909cc04