### PR TITLE
Add user profile and struggled words

### DIFF
--- a/app.py
+++ b/app.py
@@ -195,11 +195,19 @@ def transcribe():
         for w in words
         if w.get("prob") is not None and w["clean"] and w["prob"] < CONF_THRESHOLD
     ]
+    spelled_ok = [
+        w["clean"]
+        for w in words
+        if w.get("prob") is not None and w["clean"] and w["prob"] >= CONF_THRESHOLD
+    ]
     counts = session.get("struggle_counts")
     if counts is None:
         counts = USER_COUNTS.get(uid, {})
     for w in struggled:
         counts[w] = counts.get(w, 0) + 1
+    for w in spelled_ok:
+        if w in counts:
+            counts[w] = max(0, counts[w] - 1)
     session["struggle_counts"] = counts
     USER_COUNTS[uid] = counts
     save_user_counts()

--- a/templates/index.html
+++ b/templates/index.html
@@ -41,6 +41,14 @@
     border-radius:var(--radius);
     box-shadow:0 12px 24px rgba(0,0,0,.06);
     text-align:center;
+    position:relative;
+  }
+  .profile-link {
+    position:absolute;
+    top:1rem;
+    right:1rem;
+    font-size:.9rem;
+    padding:.5rem 1rem;
   }
 
   #sentence-box {
@@ -130,6 +138,7 @@
 
 <body>
   <div class="card">
+    <a href="/profile" class="btn btn-secondary profile-link">Profile</a>
     <div id="sentence-box"></div>
     <div id="loader" class="loader"></div>
     <div>
@@ -139,9 +148,6 @@
 
     <pre id="transcript"></pre>
     <div id="comparison"></div>
-    <div style="margin-top:1rem;">
-      <a href="/profile">View Profile</a>
-    </div>
   </div>
 
 <script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -139,6 +139,9 @@
 
     <pre id="transcript"></pre>
     <div id="comparison"></div>
+    <div style="margin-top:1rem;">
+      <a href="/profile">View Profile</a>
+    </div>
   </div>
 
 <script>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1.0" />
+<title>User Profile</title>
+<style>
+  body {
+    font-family: "Inter", system-ui, sans-serif;
+    background: #eef2f6;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+    margin: 0;
+  }
+  .card {
+    background: #fff;
+    padding: 2rem;
+    border-radius: 20px;
+    box-shadow: 0 12px 24px rgba(0,0,0,.06);
+    width: min(100%, 480px);
+  }
+  h1 {
+    margin-top: 0;
+    text-align: center;
+  }
+  ul { list-style: none; padding: 0; }
+  li { padding: .25rem 0; }
+  .back { margin-top: 1rem; text-align: center; }
+</style>
+</head>
+<body>
+  <div class="card">
+    <h1>Most Struggled Words</h1>
+    <ul>
+      {% for word, count in words %}
+      <li>{{ word }} - {{ count }}</li>
+      {% else %}
+      <li>No data yet.</li>
+      {% endfor %}
+    </ul>
+    <div class="back"><a href="/">Back to Practice</a></div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- track low-confidence words in the `/transcribe` endpoint
- build custom sentence prompts around top struggled words
- add user profile page to display most struggled words
- link to profile from home page

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_685721d1454483268e5cdb567daa0c0c