### PR TITLE
Fix button layout and styles

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -44,7 +44,7 @@
     position:relative;
   }
   .profile-link {
-    position:absolute;
+    position:fixed;
     top:1rem;
     right:1rem;
     font-size:.9rem;
@@ -137,8 +137,8 @@
 </head>
 
 <body>
+  <a href="/profile" class="btn btn-secondary profile-link">Profile</a>
   <div class="card">
-    <a href="/profile" class="btn btn-secondary profile-link">Profile</a>
     <div id="sentence-box"></div>
     <div id="loader" class="loader"></div>
     <div>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -26,8 +26,19 @@
     margin-top: 0;
     text-align: center;
   }
-  ul { list-style: none; padding: 0; }
-  li { padding: .25rem 0; }
+  .word-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 1rem;
+  }
+  .word-table th,
+  .word-table td {
+    text-align: left;
+    padding: .4rem .5rem;
+  }
+  .word-table tbody tr:nth-child(odd) {
+    background: #f1f5f9;
+  }
   .back { margin-top: 1rem; text-align: center; }
 
   /* ----- BUTTONS ----- */
@@ -54,13 +65,26 @@
 <body>
   <div class="card">
     <h1>Most Struggled Words</h1>
-    <ul>
-      {% for word, count in words %}
-      <li>{{ word }} - {{ count }}</li>
-      {% else %}
-      <li>No data yet.</li>
-      {% endfor %}
-    </ul>
+    <table class="word-table">
+      <thead>
+        <tr>
+          <th>Word</th>
+          <th>Count</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for word, count in words %}
+        <tr>
+          <td>{{ word }}</td>
+          <td>{{ count }}</td>
+        </tr>
+        {% else %}
+        <tr>
+          <td colspan="2">No data yet.</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
     <div class="back"><a href="/" class="btn btn-secondary">Back to Practice</a></div>
   </div>
 </body>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -29,6 +29,26 @@
   ul { list-style: none; padding: 0; }
   li { padding: .25rem 0; }
   .back { margin-top: 1rem; text-align: center; }
+
+  /* ----- BUTTONS ----- */
+  .btn {
+    display:inline-block;
+    font-size:1rem;
+    font-weight:600;
+    padding:.9rem 2rem;
+    border:none;
+    border-radius:10px;
+    cursor:pointer;
+    transition:transform .15s ease, background .15s ease;
+    margin:.5rem .25rem;
+    text-decoration:none;
+  }
+  .btn-secondary {
+    background:#e2e8f0;
+    color:#1e293b;
+  }
+  .btn:hover { transform:translateY(-2px); }
+  .btn-secondary:hover { background:#cbd5e1; }
 </style>
 </head>
 <body>
@@ -41,7 +61,7 @@
       <li>No data yet.</li>
       {% endfor %}
     </ul>
-    <div class="back"><a href="/">Back to Practice</a></div>
+    <div class="back"><a href="/" class="btn btn-secondary">Back to Practice</a></div>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- pin the profile button to the top-right of the page
- move profile button outside the card
- style "Back to Practice" link with existing button design

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68572b28844483269594727857b0f56a